### PR TITLE
Fix linting issues in event.js

### DIFF
--- a/src/js/core/event.js
+++ b/src/js/core/event.js
@@ -4,7 +4,11 @@ import {
   deleteNoteWithConnections,
 } from '../features/note/note.js';
 import { initializeConnectionDrawing } from '../features/connection/connection.js';
-import { calculateOffsetPosition, throttle, isMobileDevice } from '../utils/utils.js';
+import {
+  calculateOffsetPosition,
+  throttle,
+  isMobileDevice,
+} from '../utils/utils.js';
 import { saveStateToStorage } from '../data/storageManager.js';
 
 let selectionBox = null;
@@ -242,7 +246,7 @@ function handleTouchStart(event) {
   }
 }
 
-function handleTouchEnd(event) {
+function handleTouchEnd() {
   clearSelectionBox();
 }
 


### PR DESCRIPTION
## Summary
- Fix import statement formatting to match prettier rules
- Remove unused event parameter in handleTouchEnd function

## Test plan
- [x] Linting passes with `npm run lint`
- [x] No functional changes to existing behavior

🤖 Generated with [Claude Code](https://claude.ai/code)