### PR TITLE
Add automated version management with date stamping

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "mindmeld",
-  "version": "0.6",
+  "version": "0.7.0",
   "description": "A web-based mind mapping tool",
   "main": "src/js/app.js",
   "type": "module",
   "scripts": {
-    "start": "http-server src -p 8080 --cors",
+    "start": "npm run version:sync && http-server src -p 8080 --cors",
+    "version:sync": "node scripts/update-version.js",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write 'src/**/*.{js,html,css}'",

--- a/scripts/update-version.js
+++ b/scripts/update-version.js
@@ -8,7 +8,9 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 // Read package.json
-const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, '../package.json'), 'utf8'));
+const pkg = JSON.parse(
+  fs.readFileSync(path.join(__dirname, '../package.json'), 'utf8'),
+);
 
 // Get current date in ISO format
 const buildDate = new Date().toISOString().split('T')[0];

--- a/scripts/update-version.js
+++ b/scripts/update-version.js
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Read package.json
+const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, '../package.json'), 'utf8'));
+
+// Get current date in ISO format
+const buildDate = new Date().toISOString().split('T')[0];
+
+// Create version text with date
+const versionText = `v${pkg.version} (${buildDate})`;
+
+// Read HTML file
+const htmlPath = path.join(__dirname, '../src/index.html');
+const html = fs.readFileSync(htmlPath, 'utf8');
+
+// Update version display and cache busting parameters
+const updated = html
+  .replace(/v[0-9.]+(?:\s*\([^)]*\))?/g, versionText)
+  .replace(/(css\/styles\.css\?v=)[^"]+/g, `$1${pkg.version}`)
+  .replace(/(js\/app\.js\?v=)[^"]+/g, `$1${pkg.version}`);
+
+// Write updated HTML
+fs.writeFileSync(htmlPath, updated);
+
+console.log(`Version updated to: ${versionText}`);

--- a/src/index.html
+++ b/src/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>MindMeld</title>
-    <link rel="stylesheet" href="css/styles.css?v=0.6.5" />
+    <link rel="stylesheet" href="css/styles.css?v=0.7.0" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -85,7 +85,7 @@
       select notes<br />
       <strong>Pan & Zoom:</strong>right click &amp; drag to pan, scroll to
       zoom<br />
-      <strong><span id="version">v0.6.5</span></strong>
+      <strong><span id="version">v0.7.0 (2025-07-24)</span></strong>
     </div>
     <div id="zoom-display">5x</div>
     <div id="overlay" class="hidden">
@@ -105,6 +105,6 @@
         <button id="dismiss-button">Get Started</button>
       </div>
     </div>
-    <script type="module" src="js/app.js?v=0.6.5"></script>
+    <script type="module" src="js/app.js?v=0.7.0"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Add automated version synchronization between package.json and HTML display
- Implement ISO date stamping for continuous deployment visibility  
- Update version to 0.7.0 following semver for this new feature
- Hook version sync into npm start for seamless developer experience

## Test plan
- [x] Version sync script works correctly (tested locally)
- [x] All three version locations update: main display, CSS cache busting, JS cache busting
- [x] Version displays as "v0.7.0 (2025-07-24)" format
- [x] npm start automatically syncs version before starting server
- [ ] Verify version updates correctly on subsequent package.json changes

🤖 Generated with [Claude Code](https://claude.ai/code)