### PR TITLE
Fix dropdown menu styling for About navigation

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -58,7 +58,8 @@ html {
 
 .menu-button,
 .menu-link,
-.dropdown button {
+.dropdown button,
+.dropdown a {
   background-color: transparent;
   border: none;
   color: var(--secondary-color);
@@ -78,7 +79,8 @@ html {
 }
 
 .menu-button:active::after,
-.dropdown button:active::after {
+.dropdown button:active::after,
+.dropdown a:active::after {
   opacity: 1;
 }
 
@@ -107,7 +109,8 @@ html {
   margin: 0;
 }
 
-.dropdown button {
+.dropdown button,
+.dropdown a {
   border-radius: 0.375rem;
   width: 100%;
   display: block;
@@ -116,9 +119,15 @@ html {
   color: #374151;
   cursor: pointer;
   overflow: hidden;
+  text-decoration: none;
+  font-family: var(--font-family);
+  font-size: inherit;
+  border: none;
+  background: none;
 }
 
-.dropdown button:hover {
+.dropdown button:hover,
+.dropdown a:hover {
   background-color: #edf0ff;
 }
 


### PR DESCRIPTION
## Summary
- Extended CSS selectors to properly style anchor tags in dropdown menus
- The About dropdown was using `<a>` tags but CSS only targeted `dropdown button`
- Now both buttons and anchor tags in dropdowns have consistent styling

## Test plan
- [ ] Verify About dropdown text is styled correctly like Import/Export dropdown
- [ ] Check hover states work on both buttons and anchor links
- [ ] Test navigation functionality remains intact

🤖 Generated with [Claude Code](https://claude.ai/code)