### PR TITLE
Fix touch viewport bugs with preventDefault timing

### DIFF
--- a/src/js/interactions/adapters/TouchAdapter.js
+++ b/src/js/interactions/adapters/TouchAdapter.js
@@ -187,6 +187,9 @@ export class TouchAdapter extends BaseAdapter {
 
         // MM-212: Handle multi-touch gestures
         if (event.touches.length === 2) {
+          // Prevent browser default zoom behavior immediately
+          event.preventDefault();
+
           // Two-finger touch - initialize multi-touch state
           this.updateMultiTouchState(event.touches);
           return;


### PR DESCRIPTION
## Bug Fix Summary

Fixed critical timing issue in TouchAdapter preventDefault handling that was causing browser default zoom to override our custom touch gestures.

## Problem Identified

During desktop testing with `?mode=touch`, we discovered that `preventDefault()` was being called too late in the touch event lifecycle:

1. **touchStart**: Browser initiates default zoom decision (no preventDefault) ❌
2. **touchMove**: Our preventDefault() call (too late) ⚠️
3. **Result**: Browser zoom wins, canvas disappears

## Solution Applied

**TouchAdapter.js:191** - Added `event.preventDefault()` in touchStart handler for 2-finger gestures:

```javascript
// MM-212: Handle multi-touch gestures
if (event.touches.length === 2) {
  // Prevent browser default zoom behavior immediately
  event.preventDefault();
  
  // Two-finger touch - initialize multi-touch state
  this.updateMultiTouchState(event.touches);
  return;
}
```

## Key Insights from Testing

- **Desktop emulation limitations**: DevTools touch mode and trackpad multi-touch don't fully replicate preventDefault behavior
- **URL override works**: `?mode=touch` successfully forces touch mode for testing  
- **Real device testing required**: preventDefault effectiveness can only be validated on actual mobile devices

## Testing Status

✅ **Unit tests**: All 726 tests passing  
✅ **E2E tests**: All 9 tests passing  
✅ **Linting**: Clean (warnings only)
⏳ **Mobile testing**: Requires real device validation

## Expected Mobile Behavior After Fix

1. **No browser zoom interference**: Pinch gestures controlled by our app
2. **Two-finger pan works**: Smooth canvas panning during gestures  
3. **Custom zoom functions**: Canvas zoom instead of page zoom

## Files Changed

- `src/js/interactions/adapters/TouchAdapter.js` - Added preventDefault in touchStart

🤖 Generated with [Claude Code](https://claude.ai/code)