### PR TITLE
fix: reduce pinch zoom sensitivity by 50%

### DIFF
--- a/src/js/interactions/behaviors/ViewportBehavior.js
+++ b/src/js/interactions/behaviors/ViewportBehavior.js
@@ -108,7 +108,7 @@ export class ViewportBehavior {
     // FIXED: Direct proportional zoom level calculation from current zoom
     // scaleDelta 1.0 = no change, scaleDelta > 1.0 = zoom in, scaleDelta < 1.0 = zoom out
     // Apply relative zoom change from current zoom level for smooth control
-    const zoomDelta = Math.log2(scaleDelta) * 0.2; // 0.2x sensitivity (~10x less sensitive, requires ~half screen pinch)
+    const zoomDelta = Math.log2(scaleDelta) * 0.1; // 0.1x sensitivity (~20x less sensitive, requires larger finger movements)
     const newZoomLevel = this.zoomLevel + zoomDelta;
 
     // Apply zoom with viewport center point - applyZoomAtPoint will handle coordinate conversion


### PR DESCRIPTION
## Summary
- Reduced pinch zoom sensitivity multiplier from 0.2 to 0.1 for more controlled zooming
- Requires larger finger movements for the same zoom changes on touch devices
- Makes pinch/zoom less sensitive while maintaining smooth decimal progression

## Changes
- Modified ViewportBehavior.js line 111: changed sensitivity from 0.2x to 0.1x (~20x less sensitive than original)

## Testing
- Manual testing shows more controlled zoom behavior
- Existing E2E tests in viewport-touch-interactions.spec.js validate decimal zoom progression

🤖 Generated with [Claude Code](https://claude.ai/code)