### PR TITLE
feat: fix mobile toolbar functionality and connector selection

### DIFF
--- a/src/js/interactions/adapters/TouchAdapter.js
+++ b/src/js/interactions/adapters/TouchAdapter.js
@@ -222,6 +222,11 @@ export class TouchAdapter extends BaseAdapter {
           ) {
             logger.info(
               `TouchAdapter: Toolbar button touch detected: ${touch.target.dataset.toolbarAction}`,
+              {
+                hasToolbarBehavior: !!this.toolbarBehavior,
+                buttonElement: touch.target,
+                disabled: touch.target.disabled,
+              },
             );
             this.handleToolbarButtonInteraction(
               event,
@@ -565,11 +570,12 @@ export class TouchAdapter extends BaseAdapter {
         return;
       }
 
-      // Single tap on canvas - clear note selections and exit edit mode
+      // Single tap on canvas - clear note selections, connector selections, and exit edit mode
       logger.info(
         'TouchAdapter: Canvas tap detected - clearing selections and exiting edit mode',
       );
       noteManager.clearSelections();
+      this.clearConnectorSelections();
       this.emit('canvas.clicked');
       return;
     }
@@ -695,16 +701,27 @@ export class TouchAdapter extends BaseAdapter {
    * Handle SVG tap for connection line selection
    */
   handleSvgTap(touch, target) {
+    logger.info(
+      'TouchAdapter: SVG tap detected, checking for connector selection',
+      { targetTag: target.tagName, targetClass: target.className },
+    );
+
+    // Check if this is a connector hotspot (circle) tap
+    if (
+      target.tagName === 'circle' &&
+      target.classList.contains('connector-hotspot')
+    ) {
+      this.handleConnectorSelection(touch, target);
+      return;
+    }
+
+    // Fallback to basic line selection for other SVG elements
     if (!this.connectionBehavior) {
       logger.warn(
         'TouchAdapter: ConnectionBehavior not available for line selection',
       );
       return;
     }
-
-    logger.info(
-      'TouchAdapter: SVG tap detected, delegating to ConnectionBehavior',
-    );
 
     // Convert touch to event-like object for ConnectionBehavior
     const syntheticEvent = {
@@ -716,6 +733,91 @@ export class TouchAdapter extends BaseAdapter {
     };
 
     this.connectionBehavior.handleLineSelection(syntheticEvent, 'touch');
+  }
+
+  /**
+   * Handle connector hotspot selection - equivalent to DesktopAdapter.handleConnectorSelection
+   */
+  handleConnectorSelection(touch, hotspotElement) {
+    logger.info('🔗 TouchAdapter: Handling connector selection');
+
+    // Get the connector group element (parent of the hotspot circle)
+    const connectorGroup = hotspotElement.closest('g[data-start][data-end]');
+    if (!connectorGroup) {
+      logger.warn('Could not find connector group');
+      return;
+    }
+
+    const startId = connectorGroup.dataset.start;
+    const endId = connectorGroup.dataset.end;
+    const connectionType = connectorGroup.dataset.type;
+
+    logger.info('Connector selected:', {
+      startId,
+      endId,
+      connectionType,
+    });
+
+    // Clear previous connector selections
+    this.clearConnectorSelections();
+
+    // Apply visual selection state
+    this.applyConnectorSelection(connectorGroup);
+
+    // Emit selection event
+    if (this.eventBus) {
+      this.eventBus.emit('connector.selected', {
+        startId,
+        endId,
+        connectionType,
+        connectorGroup,
+        inputType: 'touch',
+      });
+    }
+  }
+
+  /**
+   * Clear all connector selections
+   */
+  clearConnectorSelections() {
+    const hadSelection =
+      document.querySelector('.connector-hotspot.selected') !== null;
+
+    // Remove selected class from all connector hotspots
+    document
+      .querySelectorAll('.connector-hotspot.selected')
+      .forEach((hotspot) => {
+        hotspot.classList.remove('selected');
+      });
+
+    // Remove selected class from all connection paths
+    document.querySelectorAll('path.selected').forEach((path) => {
+      path.classList.remove('selected');
+    });
+
+    // Emit deselection event if there was a selection
+    if (hadSelection && this.eventBus) {
+      this.eventBus.emit('connector.deselected', { inputType: 'touch' });
+    }
+  }
+
+  /**
+   * Apply visual selection state to a connector
+   */
+  applyConnectorSelection(connectorGroup) {
+    // Add selected class to the connector hotspot
+    const hotspot = connectorGroup.querySelector('.connector-hotspot');
+    if (hotspot) {
+      hotspot.classList.add('selected');
+    }
+
+    // Add selected class to the connection path
+    const path = connectorGroup.querySelector('path');
+    if (path) {
+      path.classList.add('selected');
+    }
+
+    logger.info('TouchAdapter: Applied connector selection visual state');
   }
 
   /**
@@ -997,10 +1099,16 @@ export class TouchAdapter extends BaseAdapter {
    * Handle toolbar button interactions - delegate to ToolbarBehavior
    */
   handleToolbarButtonInteraction(event, action) {
-    logger.info(`TouchAdapter: Handling toolbar button action: ${action}`);
+    logger.info(`TouchAdapter: Handling toolbar button action: ${action}`, {
+      hasToolbarBehavior: !!this.toolbarBehavior,
+      eventType: event?.type,
+      targetTag: event?.target?.tagName,
+    });
 
     if (!this.toolbarBehavior) {
-      logger.warn('ToolbarBehavior not available');
+      logger.error(
+        'TouchAdapter: ToolbarBehavior not available - button interaction will fail!',
+      );
       return;
     }
 
@@ -1010,9 +1118,15 @@ export class TouchAdapter extends BaseAdapter {
     // Delegate to ToolbarBehavior based on action type
     switch (action) {
       case 'delete':
+        logger.info(
+          'TouchAdapter: Delegating delete action to ToolbarBehavior',
+        );
         this.toolbarBehavior.handleDeleteAction('touch');
         break;
       case 'switch-type':
+        logger.info(
+          'TouchAdapter: Delegating switch-type action to ToolbarBehavior',
+        );
         this.toolbarBehavior.handleConnectorTypeSwitch('touch');
         break;
       default:


### PR DESCRIPTION
## Summary

Fixes critical mobile toolbar functionality issues where delete and connector switch buttons would animate but not function properly. The root cause was missing connector selection event emission in TouchAdapter.

- **Add missing connector selection functionality to TouchAdapter**
  - `handleConnectorSelection()` method for hotspot clicks  
  - `clearConnectorSelections()` with proper event emission
  - `applyConnectorSelection()` for visual state management

- **Fix connector detection in handleSvgTap()**
  - Detect connector hotspot clicks vs line clicks
  - Emit `connector.selected` events for ToolbarBehavior
  - Maintain backward compatibility with existing line selection

- **Improve canvas interaction consistency**
  - Clear connector selections on canvas tap
  - Match DesktopAdapter behavior patterns exactly

- **Enhance mobile debugging capabilities**
  - Detailed logging for toolbar button detection
  - Include behavior availability and button state info
  - Better error messaging for missing dependencies

## Technical Details

**Files Changed**: 1 file, +121 lines, -7 lines
- `src/js/interactions/adapters/TouchAdapter.js` - Core mobile interaction fixes

**Key Methods Added**:
- `handleConnectorSelection()` - Equivalent to DesktopAdapter functionality
- `clearConnectorSelections()` - Proper cleanup with event emission  
- `applyConnectorSelection()` - Visual selection state management

## Test Plan

### Mobile Delete Functionality
- [ ] Select a note on mobile → delete button should become enabled (bright)
- [ ] Tap delete button → note should actually be deleted (not just animate)
- [ ] Select multiple notes → tap delete → all notes should be deleted

### Mobile Connector Selection  
- [ ] Create connection between two notes
- [ ] Tap the center circle (hotspot) of the connection line
- [ ] Delete and switch-type buttons should become enabled
- [ ] Tap delete button → connection should be deleted
- [ ] Tap switch-type button → arrow direction should change

### Canvas Interaction
- [ ] Select connector → tap canvas → connector selection should clear
- [ ] Visual selection states should match desktop behavior

### Cross-Platform Verification
- [ ] Desktop functionality remains unchanged
- [ ] All existing tests pass
- [ ] No regressions in mouse/keyboard interactions

## Implementation Notes

This fix targets the specific mobile interaction gaps without modifying the working desktop implementation. TouchAdapter now properly emits the `connector.selected` events that ToolbarBehavior expects, enabling the context-sensitive toolbar state management.

The solution follows the existing Adapter-Behavior pattern used throughout MindMeld, ensuring consistency with the established architecture.

🤖 Generated with [Claude Code](https://claude.ai/code)