### PR TITLE
fix: Update version script to generate Prettier-compliant HTML

### DIFF
--- a/scripts/update-version.js
+++ b/scripts/update-version.js
@@ -29,12 +29,12 @@ let updated = html;
 if (updated.match(/<meta\s+name=["']app-version["'][^>]*>/)) {
   updated = updated.replace(
     /<meta\s+name=["']app-version["'][^>]*>/,
-    `<meta name="app-version" content="${pkg.version}">`,
+    `<meta name="app-version" content="${pkg.version}" />`,
   );
 } else {
   updated = updated.replace(
     /<\/head>/,
-    `  <meta name="app-version" content="${pkg.version}">\n</head>`,
+    `    <meta name="app-version" content="${pkg.version}" />\n  </head>`,
   );
 }
 
@@ -42,12 +42,12 @@ if (updated.match(/<meta\s+name=["']app-version["'][^>]*>/)) {
 if (updated.match(/<meta\s+name=["']build-date["'][^>]*>/)) {
   updated = updated.replace(
     /<meta\s+name=["']build-date["'][^>]*>/,
-    `<meta name="build-date" content="${buildDate}">`,
+    `<meta name="build-date" content="${buildDate}" />`,
   );
 } else {
   updated = updated.replace(
     /<\/head>/,
-    `  <meta name="build-date" content="${buildDate}">\n</head>`,
+    `    <meta name="build-date" content="${buildDate}" />\n  </head>`,
   );
 }
 


### PR DESCRIPTION
## Summary
Fix version sync script to generate HTML that passes Prettier formatting checks without requiring manual intervention.

## Problem
The `scripts/update-version.js` script was generating HTML5-style self-closing meta tags without trailing slashes, causing Prettier pre-push checks to fail during version bumps. This required manual formatting fixes after every version increment.

**Before** (failing Prettier):
```html
<meta name="app-version" content="1.1.1">
<meta name="build-date" content="2025-09-26">
```

**After** (Prettier-compliant):
```html
<meta name="app-version" content="1.1.1" />
<meta name="build-date" content="2025-09-26" />
```

## Solution
- Add trailing slashes to self-closing meta tags for XHTML compatibility
- Update both existing and new meta tag generation patterns
- Ensure consistent indentation for proper HTML formatting

## Benefits
- **No more manual formatting**: Version bumps work seamlessly without Prettier fixes
- **Consistent code quality**: Generated HTML matches project formatting standards
- **Smoother CI/CD**: Pre-push hooks pass immediately after version bumps

## Test plan
- [x] Test version bump generates Prettier-compliant HTML
- [x] Pre-push hooks pass without manual intervention
- [x] All automated tests pass
- [x] Script maintains existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)